### PR TITLE
Drop override boot function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,19 +91,6 @@ class Comment extends Model
 }
 
 ```
-if you use `boot()` function in Model Comment, you must define as below:
-```php
-use CounterCache {
-    boot as preBoot;
-}
-
-protected static function boot()
-{
-    self::preBoot();
-
-    // ...
-}
-```
 
 ### Add Conditions
 ```php

--- a/src/Traits/CounterCache.php
+++ b/src/Traits/CounterCache.php
@@ -6,11 +6,10 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 trait CounterCache
 {
     /**
-     * Override boot function in eloquent model
+     * Boot CounterCache
      */
-    protected static function boot()
+    protected static function bootCounterCache()
     {
-        parent::boot();
         static::created(function ($model) {
             (new self)->runCounter($model, 'increment');
         });


### PR DESCRIPTION
start from larave 5.X you doesn’t need override boot function, you can easy build boot function of trait via name `bootNameOfTrait`

see [doc](https://laravel.com/docs/5.0/eloquent#global-scopes) of laravel for more information.